### PR TITLE
Fixed note's DrawInfo not showing

### DIFF
--- a/plugins/notes/entities/entities/nut_note.lua
+++ b/plugins/notes/entities/entities/nut_note.lua
@@ -18,6 +18,8 @@ if (SERVER) then
 		end
 	end
 else
+	ENT.DrawEntityInfo = true
+	
 	function ENT:onShouldDrawEntityInfo()
 		return true
 	end


### PR DESCRIPTION
![Screenshot](http://puu.sh/ghHLH.jpg)

Also, please, take a look for this file: https://github.com/Chessnut/hl2rp/blob/1.1/plugins/radio/entities/entities/nut_note.lua
This file overriding the nut_note of Note plugin.
