### PR TITLE
Fix Scanner Screenshot Capability

### DIFF
--- a/plugins/scanner.lua
+++ b/plugins/scanner.lua
@@ -361,19 +361,7 @@ else
 				flash.DieTime = CurTime() + 0.3
 
 				timer.Simple(0.05, function()
-					local data = util.Compress(render.Capture({
-						format = "jpeg",
-						h = PICTURE_HEIGHT,
-						w = PICTURE_WIDTH,
-						quality = 35,
-						x = ScrW()*0.5 - PICTURE_WIDTH2,
-						y = ScrH()*0.5 - PICTURE_HEIGHT2
-					}))
-
-					net.Start("nutScannerData")
-						net.WriteUInt(#data, 16)
-						net.WriteData(data, #data)
-					net.SendToServer()
+					self.startPicture = true;
 				end)
 			end
 		end
@@ -395,6 +383,26 @@ else
 		if (hidden) then
 			blackAndWhite["$pp_colour_brightness"] = 0.05 + math.sin(RealTime() * 10)*0.01
 			DrawColorModify(blackAndWhite)
+		end
+	end
+	
+	function PLUGIN:PostRender()
+		if (self.startPicture) then
+			local data = util.Compress(render.Capture({
+				format = "jpeg",
+				h = PICTURE_HEIGHT,
+				w = PICTURE_WIDTH,
+				quality = 35,
+				x = ScrW()*0.5 - PICTURE_WIDTH2,
+				y = ScrH()*0.5 - PICTURE_HEIGHT2
+			}))
+
+			net.Start("nutScannerData")
+				net.WriteUInt(#data, 16)
+				net.WriteData(data, #data)
+			net.SendToServer()
+			
+			self.startPicture = false
 		end
 	end
 

--- a/plugins/scanner.lua
+++ b/plugins/scanner.lua
@@ -361,7 +361,7 @@ else
 				flash.DieTime = CurTime() + 0.3
 
 				timer.Simple(0.05, function()
-					self.startPicture = true;
+					self.startPicture = true
 				end)
 			end
 		end


### PR DESCRIPTION
Garry's Mod update on February 26 2018 made it so that render.Capture will only capture the current pixel buffer, and when called outside of a rendering hook, the pixel buffer is empty.